### PR TITLE
Update Learn.js

### DIFF
--- a/packages/dapp/src/pages/Learn.js
+++ b/packages/dapp/src/pages/Learn.js
@@ -53,7 +53,7 @@ const Learn = () => {
           className='w-1/4 px-4 py-2 mx-auto text-white bg-[#233447] rounded-md hover:bg-indigo-700 focus:outline-none focus:ring focus:ring-indigo-500'
         >
           <a
-            href='https://kernel.community/en/tokens/token-studies/honour'
+            href='https://read.kernel.community/en/tokens/token-studies/honour'
             target='_blank'
             rel='noopener noreferrer'
           >


### PR DESCRIPTION
The link to Kernel docs appears to have changed (they added a read.kernel.community subdomain). 

This PR just updates the link. 